### PR TITLE
Fix #35 (Date types don't compare correctly)

### DIFF
--- a/src/compare.js
+++ b/src/compare.js
@@ -84,8 +84,8 @@ module.exports = compareHelpers = {
 		if (a === null || b === null) {
 			return a === b;
 		}
-		if (a instanceof Date || b instanceof Date) {
-			return a === b;
+		if (a instanceof Date && b instanceof Date) {
+			return a.getTime() === b.getTime();
 		}
 		if (options.deep === -1) {
 			return typeof a === 'object' || a === b;

--- a/src/set-core_test.js
+++ b/src/set-core_test.js
@@ -7,7 +7,8 @@ var ignoreProp = function(){ return true; };
 QUnit.module("can-set core");
 
 test('set.equal', function(){
-	var res;
+	var res,
+		now;
 
 	res = set.equal(
 		{ type: 'FOLDER' },
@@ -41,6 +42,14 @@ test('set.equal', function(){
 		{foo: {}}
 	);
 	ok(!res, 'nulls and empty objects are not considered the same. (#773)');
+
+	// Issue #35
+	now = new Date();
+	res = set.equal(
+		{foo: now},
+		{foo: new Date(now.getTime())}
+	);
+	ok(res, 'date objects with same time values are considered the same. (#35)');
 
 });
 


### PR DESCRIPTION
Fix comparison by treating two Date instances as same if they have the same time value