### PR TITLE
adds algebra.id

### DIFF
--- a/src/set-core.js
+++ b/src/set-core.js
@@ -684,6 +684,45 @@ assign(Algebra.prototype, {
 		}
 
 		return combined;
+	},
+	/**
+	 * @function can-set.Algebra.prototype.id id
+	 * @parent can-set.Algebra.prototype
+	 *
+	 * @signature `algebra.id(props)`
+	 *
+	 * Returns the configured `id` property value from `props`.  If there are
+	 * multiple ids, a `JSON.stringify`-ed JSON object is returned with each
+	 * [can-set.props.id] value is returned.
+	 *
+	 * ```js
+	 * var algebra1 = new set.Algebra(set.props.id("_id"));
+	 * algebra1.id({_id: 5}) //-> 5
+	 *
+	 * var algebra2 = new set.Algebra(
+	 *   set.props.id("studentId"),
+	 *   set.props.id("classId")
+	 * );
+	 *
+	 * algebra2.id({studentId: 6, classId: "7", foo: "bar"})
+	 *     //-> '{"studentId": 6, "classId": "7"}'
+	 * ```
+	 *
+	 *   @param  {Object} obj An instance's raw data.
+	 *   @return {*|String} If a single [can-set.props.id] is configured, it's value will be returned.
+	 *   If multiple [can-set.props.id] properties are configured a `JSON.stringify`-ed object is returned.
+	 */
+	id: function(props){
+		var keys = Object.keys(this.clauses.id);
+		if(keys.length === 1) {
+			return props[keys[0]];
+		} else {
+			var id = {};
+			keys.forEach(function(key){
+				id[key] = props[key];
+			});
+			return JSON.stringify(id);
+		}
 	}
 });
 

--- a/src/set-core_test.js
+++ b/src/set-core_test.js
@@ -256,3 +256,12 @@ test('set.index', function(){
 
 	equal(index, 0);
 });
+
+test('algebra.id', function(){
+	var algebra = new set.Algebra(set.props.id("_id"));
+	QUnit.equal(algebra.id({_id: 5}), 5, "only one id, returns value");
+
+	algebra = new set.Algebra(set.props.id("studentId"), set.props.id("classId"));
+	QUnit.equal(algebra.id({studentId: 6, classId: "7", foo: "bar"}), JSON.stringify({studentId: 6, classId: "7"}), "only one id, returns set as JSON");
+
+});


### PR DESCRIPTION
fixes #45

```js
var algebra1 = new set.Algebra(set.props.id("_id"));
algebra1.id({_id: 5}) //-> 5

var algebra2 = new set.Algebra(
  set.props.id("studentId"),
  set.props.id("classId")
);

algebra2.id({studentId: 6, classId: "7", foo: "bar"})
    //-> '{"studentId": 6, "classId": "7"}'
```