### PR TITLE
Include id properties in where clause calculations

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,3 @@
-
 {
   "globals": {
     "steal": true,

--- a/src/set-core.js
+++ b/src/set-core.js
@@ -99,7 +99,7 @@ assign(Algebra.prototype, {
 
 	// Breakup `set`'s properties by clauses in the algebra.
 	// options:
-	//  - omitCluases - clauses that should not be pulled out
+  //  - omitClauses - clauses that should not be pulled out
 	//
 	// returns:
 	//   - enabled - an object of which clauses are actually being used by this set. Where is true no matter what.
@@ -113,7 +113,7 @@ assign(Algebra.prototype, {
 		var setClone = assign({}, set);
 
 		var clauses = this.clauses;
-		var checkClauses = ['order', 'paginate','id'];
+		var checkClauses = ['order', 'paginate', 'id'];
 
 		var clauseProps = {
 			enabled: {
@@ -137,7 +137,11 @@ assign(Algebra.prototype, {
 				// if it exists in the set, add it as a value for that clause
 				if(prop in setClone) {
 					valuesForClause[prop] = setClone[prop];
-					delete setClone[prop];
+
+					// id clause properties are also where clause properties, so leave them to be added to where clause
+					if (clauseName !== 'id') {
+						delete setClone[prop];
+					}
 				}
 			}
 

--- a/src/set-core_test.js
+++ b/src/set-core_test.js
@@ -53,7 +53,6 @@ test('set.equal', function(){
 
 });
 
-
 test('set.subset', function(){
 	var res;
 
@@ -198,7 +197,6 @@ test('set.intersection Array', function(){
 
 });
 
-
 test('set.has', function(){
 	var res;
 
@@ -237,6 +235,19 @@ test('set.has', function(){
 		{ foo: ignoreProp, bar: ignoreProp, kind: ignoreProp }
 	);
 	ok(res,	'ignores nulls');
+
+	var algebra = new set.Algebra(set.props.id('invoice_number'), set.props.id('product_code'));
+	res = algebra.has(
+		{invoice_number: 5},
+		{invoice_number: 6, product_code: 10, product_name: 'Soap'}
+	);
+	ok(res === false, 'understands compound ids subset exclusion');
+
+	res = algebra.has(
+		{invoice_number: 5},
+		{invoice_number: 5, product_code: 10, product_name: 'Soap'}
+	);
+	ok(res, 'understands compound id subset inclusion');
 });
 
 test('set.index', function(){


### PR DESCRIPTION
Fixes #62 

Id clauses can be considered special cased where clauses. The change includes id properties as where properties, so when doing where clause calculations like subset & has the ids are also considered.

